### PR TITLE
refactor: ♻️ (`web`) Panda CSSに色のセマンティックトークンを追加した。

### DIFF
--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@pandacss/dev';
-import radixColorsPreset from 'pandacss-preset-radix-colors';
 import { breakpoints } from '@/styles/tokens/breakpoints';
+import { radixColorsWithScaleAliasesPreset } from '@/styles/tokens/radixColorsPreset';
 
 export default defineConfig({
   // Whether to use css reset
@@ -35,11 +35,22 @@ export default defineConfig({
   presets: [
     // Radix Scales provider for PandaCSS by milandekruijf
     // Refer: https://github.com/milandekruijf/pandacss-preset-radix-colors
-    radixColorsPreset({
+    radixColorsWithScaleAliasesPreset({
       darkMode: {
         condition: '[data-theme="dark"] &',
       },
-      autoP3: false,
+      autoP3: true,
+      scaleAliases: {
+        keyplate: 'slate',
+        primary: 'pink',
+        secondary: 'blue',
+        info: 'cyan',
+        success: 'green',
+        warning: 'yellow',
+        danger: 'crimson',
+      },
+      aliasMode: 'reference',
+      includedRadixScales: ['white', 'black', 'cyan', 'yellow', 'pink', 'purple'],
     }),
 
     // Re-add the panda preset if you want to keep

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -23,8 +23,8 @@ const RootLayout: FC<RootLayoutProps> = ({ children }) => (
         display: 'flex',
         minHeight: 'screen',
         flexDirection: 'column',
-        background: 'slate.2',
-        color: 'slate.12',
+        background: 'keyplate.2',
+        color: 'keyplate.12',
         overflowX: 'hidden',
       })}
     >

--- a/apps/web/src/components/Globe/Globe.tsx
+++ b/apps/web/src/components/Globe/Globe.tsx
@@ -52,8 +52,8 @@ export const Globe = ({ css: cssProps = {}, ...props }: GlobeProps): ReactNode =
       diffuse: 1.2,
       mapSamples: 16000,
       mapBrightness: 6,
-      baseColor: convertHexToRgb('#FBFCFD'), // slate.2
-      markerColor: convertHexToRgb('#DFE3E6'), // slate.6
+      baseColor: convertHexToRgb('#FBFCFD'), // keyplate.2
+      markerColor: convertHexToRgb('#DFE3E6'), // keyplate.6
       glowColor: globeGlowColorAttribute,
       markers: [
         // longitude latitude

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -86,8 +86,8 @@ export const Header = ({ ...props }: HeaderProps): ReactNode => {
             gap: '3',
             direction: 'row',
             align: 'center',
-            bg: 'slate.12',
-            color: 'slate.1',
+            bg: 'keyplate.12',
+            color: 'keyplate.1',
             rounded: 'full',
           })}
         >

--- a/apps/web/src/components/PhotoCard/PhotoCard.tsx
+++ b/apps/web/src/components/PhotoCard/PhotoCard.tsx
@@ -11,7 +11,7 @@ export const photoCardSlotRecipe = sva({
       w: '48',
       h: 'fit-content',
       flexShrink: '0',
-      bg: 'slate.2',
+      bg: 'keyplate.2',
       shadow: 'lg',
       p: '4',
       display: 'flex',
@@ -23,12 +23,12 @@ export const photoCardSlotRecipe = sva({
     image: {
       w: 'full',
       objectFit: 'cover',
-      bg: 'slate.3',
+      bg: 'keyplate.3',
     },
     label: {
       fontFamily: 'code',
       lineHeight: '1.25',
-      color: 'slate.11',
+      color: 'keyplate.11',
     },
   },
 });

--- a/apps/web/src/styles/tokens/radixColorsPreset.ts
+++ b/apps/web/src/styles/tokens/radixColorsPreset.ts
@@ -1,0 +1,148 @@
+import { definePreset } from '@pandacss/dev';
+import type { Preset } from '@pandacss/dev';
+import radixColorsPreset from 'pandacss-preset-radix-colors';
+
+/**
+ * Array of radix scale names.
+ * @see https://www.radix-ui.com/colors/docs/palette-composition/composing-a-palette
+ */
+const radixScaleNames = [
+  'white',
+  'black',
+  'bronze',
+  'gold',
+  'brown',
+  'orange',
+  'tomato',
+  'red',
+  'ruby',
+  'crimson',
+  'pink',
+  'plum',
+  'purple',
+  'violet',
+  'iris',
+  'indigo',
+  'blue',
+  'cyan',
+  'teal',
+  'jade',
+  'green',
+  'grass',
+  'sky',
+  'mint',
+  'lime',
+  'yellow',
+  'amber',
+  'gray',
+  'mauve',
+  'slate',
+  'sage',
+  'olive',
+  'sand',
+] as const;
+
+type RadixColorsWithScaleAliasesPresetOptions = {
+  scaleAliases?: Record<string, (typeof radixScaleNames)[number]>;
+  aliasMode?: 'clone' | 'reference';
+  includedRadixScales?: (typeof radixScaleNames)[number][];
+} & Parameters<typeof radixColorsPreset>[0];
+
+/**
+ * Generates a Radix colors preset with scale aliases.
+ * @param options - The options for generating the preset.
+ * @param options.scaleAliases - The scale alias map.
+ * @param options.includedRadixScales - The included radix scales. 
+ *  @example
+ * ```ts
+ * radixColorsWithScaleAliasesPreset({
+      darkMode: {
+        condition: '[data-theme="dark"] &',
+      },
+      autoP3: true,
+      scaleAliases: {
+        keyplate: 'slate',
+        primary: 'pink',
+        secondary: 'blue',
+        info: 'cyan',
+        success: 'green',
+        warning: 'yellow',
+        danger: 'crimson',
+      },
+    })
+ * ```
+ * @returns The generated preset.
+ */
+export function radixColorsWithScaleAliasesPreset({
+  scaleAliases = {},
+  aliasMode = 'clone',
+  includedRadixScales = [],
+  ...baseOptions
+}: RadixColorsWithScaleAliasesPresetOptions) {
+  const basePreset = radixColorsPreset(baseOptions);
+
+  const referencedScaleNames = aliasMode === 'reference' ? Object.values(scaleAliases) : [];
+  const filteredScalesColors = Object.fromEntries(
+    Object.entries(basePreset.theme?.extend?.semanticTokens?.colors ?? {}).filter(([scaleName]) => {
+      if (includedRadixScales) {
+        return (
+          includedRadixScales.includes(scaleName as (typeof radixScaleNames)[number]) ||
+          referencedScaleNames.includes(scaleName as (typeof radixScaleNames)[number])
+        );
+      }
+      return true;
+    }),
+  );
+
+  const scaleAliasesColors = (() => {
+    switch (aliasMode) {
+      case 'clone':
+        return Object.fromEntries(
+          Object.entries(scaleAliases).map(([alias, scaleName]) => {
+            const scale = basePreset.theme?.extend?.semanticTokens?.colors?.[scaleName];
+            if (!scale) {
+              throw new Error(`🐼 [radixColorsWithScaleAliasesPreset] Scale ${scaleName} does not exist.`);
+            }
+            // Replace scaleName with alias in each references in the scale
+            // Search for `{colors.${scaleName}.${string}}` and replace it with `{colors.${alias}.${string}}` recursively
+            const regex = new RegExp(`"{colors.${scaleName}.([a-zA-Z\\.0-9]*)}"`, 'g');
+            const scaleWithAlias: typeof scale = JSON.parse(
+              JSON.stringify(scale).replaceAll(regex, `"{colors.${alias}.$1}"`),
+            );
+
+            return [alias, scaleWithAlias];
+          }),
+        );
+      case 'reference':
+        return Object.fromEntries(
+          Object.entries(scaleAliases).map(([alias, scaleName]) => {
+            const scale = basePreset.theme?.extend?.semanticTokens?.colors?.[scaleName];
+            if (!scale) {
+              throw new Error(`🐼 [radixColorsWithScaleAliasesPreset] Scale ${scaleName} does not exist.`);
+            }
+            const tones = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const;
+            const scaleWithAlias: typeof scale = Object.fromEntries(
+              tones.map((key) => [
+                key,
+                {
+                  value: `{colors.${scaleName}.${key}}`,
+                },
+              ]),
+            );
+            return [alias, scaleWithAlias];
+          }),
+        );
+    }
+  })();
+
+  // Deep merge the two presets
+  const preset: Preset = { ...basePreset };
+  if (preset.theme?.extend?.semanticTokens?.colors) {
+    preset.theme.extend.semanticTokens.colors = {
+      ...filteredScalesColors,
+      ...scaleAliasesColors,
+    };
+  }
+
+  return definePreset(preset);
+}


### PR DESCRIPTION
- close #12 