### PR TITLE
fix: 🐛 (`<Image>`) `sizes`プロパティの構文を修正した  (#64)

### DIFF
--- a/apps/web/src/components/Image/Image.tsx
+++ b/apps/web/src/components/Image/Image.tsx
@@ -42,7 +42,7 @@ const generateSizes = (sizes: ImageProps['sizes']): string => {
       }
 
       const breakpoint = key as keyof typeof breakpoints;
-      return `@media(min-width: ${breakpoints[breakpoint]}) ${value}`;
+      return `(min-width: ${breakpoints[breakpoint]}) ${value}`;
     })
     .join(', ');
 };


### PR DESCRIPTION
- 今までのものじゃ意味がなかった
