### PR TITLE
chore: 🔧 (`.npmrc`) `save-exact`を有効化した。  (#69)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+save-exact=true
 engine-strict=true
 auto-install-peers=true
 public-hoist-pattern[]=*eslint*


### PR DESCRIPTION
- close #69

- renovateで毎回pin dependenciesのPRが開かれるのが面倒なため
