### PR TITLE
Radix UI PrimitivesのCSSセレクタを提供するPanda CSSのプラグインを作成した。

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -69,6 +69,7 @@
     "critters": "0.0.20",
     "eslint-config-custom-next": "workspace:*",
     "panda-preset-radix-colors": "workspace:*",
+    "panda-preset-radix-ui": "workspace:*",
     "jest-mock": "29.7.0",
     "mdx": "0.3.1",
     "postcss": "8.4.35",

--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@pandacss/dev';
 import { radixColorsPreset } from 'panda-preset-radix-colors';
+import { radixUIPreset } from 'panda-preset-radix-ui';
 import {
   markupHeadingRecipe,
   markupHrRecipe,
@@ -89,6 +90,11 @@ export default defineConfig({
       },
       colorScales: ['white', 'black'],
       withoutAlpha: false,
+    }),
+
+    radixUIPreset({
+      prefix: 'radix',
+      selectorNameCase: 'camelCase',
     }),
 
     // Re-add the panda preset if you want to keep

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -9,7 +9,7 @@ module.exports = {
     'prettier',
   ],
   parser: '@typescript-eslint/parser',
-  ignorePatterns: ['.turbo', 'node_modules', '**/*.js', '**/*.mjs', '**/*.jsx'],
+  ignorePatterns: ['.turbo', 'node_modules', 'dist', '**/*.js', '**/*.mjs', '**/*.jsx', 'tsup.config.ts'],
   rules: {
     'import/order': [
       'error',

--- a/packages/panda-preset-radix-ui/.eslintrc.js
+++ b/packages/panda-preset-radix-ui/.eslintrc.js
@@ -1,0 +1,9 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ['custom'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/packages/panda-preset-radix-ui/.lintstagedrc.js
+++ b/packages/panda-preset-radix-ui/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// This file is used by lint-staged to run linting and formatting on staged files
+
+module.exports = {
+  '**/*.{js,jsx,cjs,mjs,ts,tsx}': 'pnpm --filter empty-package eslint',
+  '**/*.{js,jsx,cjs,mjs,ts,tsx,md,html,css,json,yaml,yml}':
+    'pnpm --filter empty-packag prettier --ignore-unknown --check',
+};

--- a/packages/panda-preset-radix-ui/package.json
+++ b/packages/panda-preset-radix-ui/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "panda-preset-radix-ui",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --dts",
+    "build-fast": "tsup --no-dts",
+    "dev": "pnpm build-fast --watch",
+    "lint": "eslint ."
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@pandacss/dev": "0.31.0"
+  },
+  "devDependencies": {
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
+  }
+}

--- a/packages/panda-preset-radix-ui/src/case.ts
+++ b/packages/panda-preset-radix-ui/src/case.ts
@@ -1,0 +1,42 @@
+import type { GetCaseNames, GetName } from './type';
+
+/**
+ * Converts an array of words into a camel case string.
+ * @param words - The array of words to convert.
+ * @returns The camelCase string.
+ */
+const getCamelCaseName: GetName = (words) =>
+  words
+    .map((word, index) => {
+      if (index === 0) {
+        return word.toLowerCase();
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join('');
+
+/**
+ * Converts an array of words into a kebab-case string with hyphens,
+ *
+ * @param words - An array of words to be converted.
+ * @returns The hyphen-kebab case name.
+ */
+const getHyphenKebabCaseName: GetName = (words) => words.join('-').toLowerCase();
+
+/**
+ * Converts an array of words into a kebab_case string with underscores,
+ * and returns the result in lowercase.
+ *
+ * @param words - An array of words to be converted.
+ * @returns The underscore_kebab case name.
+ */
+const getUnderscoreKebabCaseName: GetName = (words) => words.join('_').toLowerCase();
+
+/**
+ * A map of the available case names and their respective functions.
+ */
+export const getCaseNames: GetCaseNames = {
+  camelCase: getCamelCaseName,
+  'kebab-case': getHyphenKebabCaseName,
+  kebab_case: getUnderscoreKebabCaseName,
+};

--- a/packages/panda-preset-radix-ui/src/index.ts
+++ b/packages/panda-preset-radix-ui/src/index.ts
@@ -1,0 +1,1 @@
+export { radixUIPreset } from './preset';

--- a/packages/panda-preset-radix-ui/src/preset.ts
+++ b/packages/panda-preset-radix-ui/src/preset.ts
@@ -1,0 +1,59 @@
+import { definePreset } from '@pandacss/dev';
+import { getCaseNames } from './case';
+import type { PandaPresetRadixCssSelectorOptions } from './type';
+
+export const radixUIPreset = async (options: PandaPresetRadixCssSelectorOptions) => {
+  const { prefix, selectorNameCase } = options;
+  const getName = getCaseNames[selectorNameCase];
+  return definePreset({
+    theme: {
+      extend: {
+        tokens: {
+          sizes: {
+            //  <Select> https://www.radix-ui.com/primitives/docs/components/select
+            [getName([prefix, 'Select', 'Content', 'availableWidth'])]: {
+              value: 'var(--radix-select-content-available-width)',
+              description:
+                'The remaining width between the trigger and the boundary edge. Only present when position="popper".',
+            },
+            [getName([prefix, 'Select', 'Content', 'availableHeight'])]: {
+              value: 'var(--radix-select-content-available-height)',
+              description:
+                'The remaining height between the trigger and the boundary edge. Only present when position="popper".',
+            },
+            [getName([prefix, 'Select', 'Trigger', 'width'])]: {
+              value: 'var(--radix-select-trigger-width)',
+              description: 'The width of the trigger. Only present when position="popper".',
+            },
+            [getName([prefix, 'Select', 'Trigger', 'height'])]: {
+              value: 'var(--radix-select-trigger-height)',
+              description: 'The height of the trigger. Only present when position="popper".',
+            },
+          },
+        },
+      },
+    },
+    conditions: {
+      extend: {
+        //  <Select> https://www.radix-ui.com/primitives/docs/components/select
+        [getName([prefix, 'Select', 'Trigger', 'state', 'open'])]: '&[data-state="open"]',
+        [getName([prefix, 'Select', 'Trigger', 'state', 'closed'])]: '&[data-state="closed"]',
+        [getName([prefix, 'Select', 'Trigger', 'disabled'])]: '&[data-disabled]',
+        [getName([prefix, 'Select', 'Trigger', 'placeholder'])]: '&[data-placeholder]',
+        [getName([prefix, 'Select', 'Content', 'state', 'open'])]: '&[data-state="open"]',
+        [getName([prefix, 'Select', 'Content', 'state', 'closed'])]: '&[data-state="closed"]',
+        [getName([prefix, 'Select', 'Content', 'side', 'left'])]: '&[data-side="left"]',
+        [getName([prefix, 'Select', 'Content', 'side', 'right'])]: '&[data-side="right"]',
+        [getName([prefix, 'Select', 'Content', 'side', 'top'])]: '&[data-side="top"]',
+        [getName([prefix, 'Select', 'Content', 'side', 'bottom'])]: '&[data-side="bottom"]',
+        [getName([prefix, 'Select', 'Content', 'align', 'start'])]: '&[data-align="start"]',
+        [getName([prefix, 'Select', 'Content', 'align', 'end'])]: '&[data-align="end"]',
+        [getName([prefix, 'Select', 'Content', 'align', 'center'])]: '&[data-align="center"]',
+        [getName([prefix, 'Select', 'Item', 'state', 'checked'])]: '&[data-state="checked"]',
+        [getName([prefix, 'Select', 'Item', 'state', 'unchecked'])]: '&[data-state="unchecked"]',
+        [getName([prefix, 'Select', 'Item', 'highlighted'])]: '&[data-highlighted]',
+        [getName([prefix, 'Select', 'Item', 'disabled'])]: '&[data-disabled]',
+      },
+    },
+  });
+};

--- a/packages/panda-preset-radix-ui/src/type.ts
+++ b/packages/panda-preset-radix-ui/src/type.ts
@@ -1,0 +1,10 @@
+export type GetName = (words: string[]) => string;
+
+export type SelectorNameCase = 'camelCase' | 'kebab-case' | 'kebab_case';
+
+export type GetCaseNames = Record<SelectorNameCase, GetName>;
+
+export type PandaPresetRadixCssSelectorOptions = {
+  prefix: string;
+  selectorNameCase: SelectorNameCase;
+};

--- a/packages/panda-preset-radix-ui/tsconfig.json
+++ b/packages/panda-preset-radix-ui/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/node.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/panda-preset-radix-ui/tsup.config.ts
+++ b/packages/panda-preset-radix-ui/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/classname.ts'],
+  format: ['cjs', 'esm'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       panda-preset-radix-colors:
         specifier: workspace:*
         version: link:../../packages/panda-preset-radix-colors
+      panda-preset-radix-ui:
+        specifier: workspace:*
+        version: link:../../packages/panda-preset-radix-ui
       postcss:
         specifier: 8.4.35
         version: 8.4.35

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,19 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
 
+  packages/panda-preset-radix-ui:
+    dependencies:
+      '@pandacss/dev':
+        specifier: 0.31.0
+        version: 0.31.0(typescript@5.3.3)
+    devDependencies:
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:../eslint-config-custom
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+
   packages/rehype-image-optimizer:
     dependencies:
       plaiceholder:
@@ -8863,7 +8876,7 @@ packages:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -8910,42 +8923,12 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(eslint@8.56.0)
       get-tsconfig: 4.4.0
       globby: 13.1.3
       is-core-module: 2.13.1
       is-glob: 4.0.3
       synckit: 0.8.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.19.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3)(eslint@8.56.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
-      debug: 3.2.7
-      eslint: 8.56.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8979,38 +8962,31 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.56.0):
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
+  /eslint-module-utils@2.8.0(eslint-import-resolver-node@0.3.9)(eslint@8.56.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
-      array-includes: 3.1.7
-      array.prototype.findlastindex: 1.2.3
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
       debug: 3.2.7
-      doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.19.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3)(eslint@8.56.0)
-      hasown: 2.0.0
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.7
-      object.groupby: 1.0.1
-      object.values: 1.1.7
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
     dev: false
 
@@ -9034,6 +9010,40 @@ packages:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.0.1)(eslint-import-resolver-node@0.3.9)(eslint@8.56.0)
+      hasown: 2.0.0
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.7
+      object.groupby: 1.0.1
+      object.values: 1.1.7
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: false
+
+  /eslint-plugin-import@2.29.1(eslint@8.56.0):
+    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.findlastindex: 1.2.3
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.56.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.0(eslint-import-resolver-node@0.3.9)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -16505,7 +16515,7 @@ packages:
       browserslist: '>= 4.21.0'
     dependencies:
       browserslist: 4.22.2
-      escalade: 3.1.1
+      escalade: 3.1.2
       picocolors: 1.0.0
 
   /update-notifier@6.0.2:

--- a/reoiam-dev.code-workspace
+++ b/reoiam-dev.code-workspace
@@ -13,6 +13,10 @@
       "path": "packages/panda-preset-radix-colors",
     },
     {
+      "name": "📦 panda-preset-radix-ui",
+      "path": "packages/panda-preset-radix-ui",
+    },
+    {
       "name": "📦 rehype-image-optimizer",
       "path": "packages/rehype-image-optimizer",
     },


### PR DESCRIPTION
- close #73

- build: 📦️ (`panda-preset-radix-ui`) Radix UI PrimitivesのCSSセレクタを提供するPanda CSSのプラグインを作成した。  (#73)
- chore: 🔧 (`panda.config.ts`) Radix UI PrimitivesのCSSセレクタを提供するPanda CSSのプラグインを設定に追加した。  (#73)
