### PR TITLE
feat: ✨ (`<Header>`) Add top-level navigation links (#128)

### DIFF
--- a/apps/web/docs/contacts.mdx
+++ b/apps/web/docs/contacts.mdx
@@ -1,0 +1,48 @@
+---
+title: Contacts
+date: 2024-02-03
+description: This page demonstrates the usage of MDX briefly.
+emoji: 💬
+---
+
+✨ Lorem ipsum dolor sit amet, consectetur adipisicing elit. A alias asperiores atque autem.
+
+![New Jeans, my love](https://s3-ap-northeast-1.amazonaws.com/pf-web/fanclubs/148/assets/229/images/top/main.jpg?20230707125959)
+
+# Hello, New Jeans!
+
+- Create a list by starting a line with `+`, `-`, or `*`
+- Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    - Ac tristique libero volutpat at
+    * Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
+- Very easy!
+
+| Syntax                                          | Output                                    |
+| ----------------------------------------------- | ----------------------------------------- |
+| `` `console.log('Hi'){:js}` ``                  | `console.log('Hi'){:js}`                  |
+| `` `from matplotlib import plot as plt{:py}` `` | `from matplotlib import plot as plt{:py}` |
+| `$` `\sum_{n=1}^{10} n^2{:tex}` `$`             | $\sum_{n=1}^{10} n^2$                     |
+| `$` `\int_{0}^{\infty} e^{-x} dx{:tex}` `$`     | $\int_{0}^{\infty} e^{-x} dx$             |
+
+$$
+  \frac{\pi}{2} =
+  \left( \int_{0}^{\infty} \frac{\sin x}{\sqrt{x}} dx \right)^2 =
+  \sum_{k=0}^{\infty} \frac{(2k)!}{2^{2k}(k!)^2} \frac{1}{2k+1} =
+  \prod_{k=1}^{\infty} \frac{4k^2}{4k^2 - 1}
+$$
+
+> [!NOTE]  
+> Highlights information that users should take into account, even when skimming.
+> `console.log('Hi'){:js}` $\int_{0}^{\infty} e^{-x} dx$ **This is bold text** _This is italic text_ ~~Strikethrough~~
+
+```ts showLineNumbers
+export const generateStaticParams = async () => {
+  const params = allContentDocuments.map((post) => ({
+    slug: post._raw.flattenedPath.split('/'),
+  }));
+  console.log(params);
+  return params;
+};
+```

--- a/apps/web/docs/resume.mdx
+++ b/apps/web/docs/resume.mdx
@@ -1,5 +1,5 @@
 ---
-title: Education
+title: Resume
 date: 2024-02-03
 description: CS Major at NITIC, TOEIC 950
 emoji: 🎓

--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -168,6 +168,7 @@ export default defineConfig({
       // NOTE: Make sure these selectors match the configurations passed to `next-themes` ThemeProvider
       light: "[data-theme='light'] &",
       dark: "[data-theme='dark'] &",
+      descendantIcon: '& .lucide', // See https://lucide.dev/guide/advanced/global-styling
     },
   },
 

--- a/apps/web/src/features/navigation/components/Header/Header.story.tsx
+++ b/apps/web/src/features/navigation/components/Header/Header.story.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from '@storybook/test';
+import { Header } from './Header';
+
+type Story = StoryObj<typeof Header>;
+
+const meta: Meta<typeof Header> = {
+  component: Header,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button');
+    await userEvent.click(trigger);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await userEvent.keyboard('{Escape}');
+  },
+};

--- a/apps/web/src/features/navigation/components/Header/Header.tsx
+++ b/apps/web/src/features/navigation/components/Header/Header.tsx
@@ -1,11 +1,25 @@
 import { GithubIcon } from 'lucide-react';
+import { Briefcase, AtSign, Sparkle, Code, Menu, X } from 'lucide-react';
 import type { ReactNode, ComponentPropsWithoutRef } from 'react';
 import { ThemeSelect } from '../ThemeSelect/ThemeSelect';
+import { TopNavigationLink } from '../TopNavigation/TopNavigationLink';
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerScrollArea,
+  DrawerKnob,
+  DrawerTitle,
+  DrawerClose,
+} from '@/components/Drawer/Drawer';
 import { Image } from '@/components/Image/Image';
 import { Link } from '@/components/Link/Link';
 import HeaderIconImage from '@public/icon.webp';
 import { css } from 'styled-system/css';
 import { flex } from 'styled-system/patterns';
+
 export type HeaderProps = ComponentPropsWithoutRef<'header'>;
 
 /**
@@ -69,7 +83,6 @@ export const Header = ({ ...props }: HeaderProps): ReactNode => {
             fontFamily: 'heading',
             maxW: '12rem',
             lineHeight: '1.25',
-            // backdropFilter: 'blur(8px) saturate(130%) contrast(30%) brightness(150%)',
           })}
         >
           reoiam.dev
@@ -77,6 +90,36 @@ export const Header = ({ ...props }: HeaderProps): ReactNode => {
           Reo HAKUTA
         </p>
       </div>
+      <nav
+        className={css({
+          pos: 'absolute',
+          w: 'fit-content',
+          h: '12',
+          top: '4',
+          left: '0',
+          right: '0',
+          mx: 'auto',
+          display: 'flex',
+          rounded: 'xl',
+          flexDir: 'row',
+          bg: 'keyplate.a.3',
+          p: '1',
+          backdropFilter: 'blur(8px) saturate(130%)',
+          mdDown: {
+            display: 'none',
+          },
+        })}
+      >
+        <TopNavigationLink href="/docs/resume">
+          <Briefcase /> Resume
+        </TopNavigationLink>
+        <TopNavigationLink href="/docs/works">
+          <Sparkle /> Works
+        </TopNavigationLink>
+        <TopNavigationLink href="/docs/contacts">
+          <AtSign /> Contacts
+        </TopNavigationLink>
+      </nav>
       <div
         className={flex({
           direction: 'row',
@@ -95,7 +138,10 @@ export const Header = ({ ...props }: HeaderProps): ReactNode => {
             fontFamily: 'heading',
             px: '4',
             py: '2',
-            gap: '3',
+            smDown: {
+              p: '3',
+            },
+            gap: '1',
             direction: 'row',
             align: 'center',
             bg: 'keyplate.12',
@@ -103,11 +149,104 @@ export const Header = ({ ...props }: HeaderProps): ReactNode => {
             rounded: 'full',
           })}
         >
-          <GithubIcon />
-          <span>
-            <span className={css({ smDown: { display: 'none' } })}>Open </span>GitHub
-          </span>
+          <GithubIcon
+            className={css({
+              display: 'inline',
+              w: '4',
+              h: '4',
+            })}
+          />
+          <span className={css({ smDown: { srOnly: true } })}>Open GitHub</span>
         </Link>
+        <Drawer direction={'right'}>
+          <DrawerTrigger asChild>
+            <button
+              aria-label="Open menu"
+              type="button"
+              className={flex({
+                fontFamily: 'heading',
+                p: '3',
+                direction: 'row',
+                justifyContent: 'center',
+                align: 'center',
+                rounded: 'full',
+                bg: 'keyplate.a.3',
+                backdropFilter: 'blur(8px) saturate(130%)',
+                cursor: 'pointer',
+                border: '1px solid',
+                borderColor: 'keyplate.a.1',
+              })}
+            >
+              <Menu
+                className={css({
+                  display: 'inline',
+                  w: '4',
+                  h: '4',
+                })}
+              />
+            </button>
+          </DrawerTrigger>
+          <DrawerPortal>
+            <DrawerOverlay />
+            <DrawerContent
+              className={css({
+                pt: '8',
+                pl: '0',
+                _light: {
+                  bg: 'keyplate.1',
+                },
+                _dark: {
+                  bg: 'keyplate.a.3',
+                  backdropFilter: 'blur(12px) saturate(140%) brightness(50%)',
+                },
+              })}
+            >
+              <DrawerClose asChild>
+                <button
+                  aria-label="Close menu"
+                  type="button"
+                  className={flex({
+                    fontFamily: 'heading',
+                    w: '12',
+                    h: '12',
+                    direction: 'row',
+                    justifyContent: 'center',
+                    align: 'center',
+                    rounded: 'full',
+                    cursor: 'pointer',
+                  })}
+                >
+                  <X />
+                </button>
+              </DrawerClose>
+              <DrawerKnob />
+              <DrawerScrollArea>
+                <DrawerTitle>Menu</DrawerTitle>
+                <nav
+                  className={css({
+                    display: 'flex',
+                    flexDir: 'column',
+                    alignItems: 'stretch',
+                    textDecoration: 'underline',
+                  })}
+                >
+                  <TopNavigationLink href="/docs/resume">
+                    <Briefcase /> Resume
+                  </TopNavigationLink>
+                  <TopNavigationLink href="/docs/works">
+                    <Sparkle /> Works
+                  </TopNavigationLink>
+                  <TopNavigationLink href="/docs/contacts">
+                    <AtSign /> Contacts
+                  </TopNavigationLink>
+                  <TopNavigationLink href="/api/swagger" target="_blank">
+                    <Code /> API Reference
+                  </TopNavigationLink>
+                </nav>
+              </DrawerScrollArea>
+            </DrawerContent>
+          </DrawerPortal>
+        </Drawer>
       </div>
     </header>
   );

--- a/apps/web/src/features/navigation/components/TopNavigation/TopNavigationLink.story.tsx
+++ b/apps/web/src/features/navigation/components/TopNavigation/TopNavigationLink.story.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from '@storybook/test';
+import { Newspaper } from 'lucide-react';
+import { TopNavigationLink } from './TopNavigationLink';
+import { css } from 'styled-system/css';
+
+type Story = StoryObj<typeof TopNavigationLink>;
+
+const meta: Meta<typeof TopNavigationLink> = {
+  component: TopNavigationLink,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className={css({ w: '72' })}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    href: '/docs/example',
+    children: (
+      <>
+        <Newspaper />
+        Example
+      </>
+    ),
+  },
+  argTypes: {},
+};
+
+export default meta;
+
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+    expect(link).toHaveAttribute('href', args.href);
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+    expect(link).toHaveAttribute('href', args.href);
+    expect(link).toHaveAttribute('aria-current', 'page');
+  },
+};

--- a/apps/web/src/features/navigation/components/TopNavigation/TopNavigationLink.tsx
+++ b/apps/web/src/features/navigation/components/TopNavigation/TopNavigationLink.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import Link from 'next/link';
+import type { LinkProps } from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useMemo } from 'react';
+import type { ReactNode, ComponentPropsWithoutRef } from 'react';
+import { cx, cva } from 'styled-system/css';
+
+export const topNavigationLinkRecipe = cva({
+  base: {
+    display: 'flex',
+    flexDir: 'row',
+    gap: '1',
+    justifyContent: 'start',
+    alignItems: 'center',
+    fontFamily: 'heading',
+    px: '4',
+    py: '2',
+    rounded: 'lg',
+    _descendantIcon: { display: 'inline', w: '4', h: '4' },
+  },
+  variants: {
+    selected: {
+      true: {
+        color: 'keyplate.11',
+        cursor: 'not-allowed',
+      },
+      false: {
+        _hover: {
+          bg: 'keyplate.a.3',
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    selected: false,
+  },
+});
+
+export type TopNavigationLinkProps = LinkProps &
+  Omit<ComponentPropsWithoutRef<'a'>, keyof LinkProps> & {
+    className?: string;
+    selected?: boolean;
+    children: ReactNode;
+  };
+
+export const TopNavigationLink = ({
+  href,
+  className,
+  selected,
+  children,
+  ...props
+}: TopNavigationLinkProps): ReactNode => {
+  // Retrieve the current path starting with /.
+  // Refer: https://nextjs.org/docs/app/api-reference/functions/use-pathname
+  const currentPath = usePathname(); // e.g. `/docs/works/shelfree`
+  // Check if the current path is the same as the href.
+  const isBeingOpened = useMemo(() => currentPath === href.toString(), [currentPath, href]);
+
+  const link = topNavigationLinkRecipe({
+    selected: selected || isBeingOpened,
+  });
+
+  return (
+    <Link
+      href={href}
+      className={cx(link, className)}
+      aria-current={selected || isBeingOpened ? 'page' : undefined}
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+};


### PR DESCRIPTION
- close #128 

- chore: 🔧 (PandaCSS) Add a condition to style descendant lucide icons  (#128)
- feat: ✨ (`<TopNavigationLink>`) Add a link component for top-level navigation  (#128)
- doc: 📝 (web) Arrange docs  (#128)
- feat: ✨ (`<Header>`) Add top-level navigation links  (#128)

<img width="1311" alt="image" src="https://github.com/ReoHakase/reoiam-dev/assets/16751535/30079e24-b18e-403d-891d-2e0e96eaeb84">

